### PR TITLE
feat: add polyphony limit (max simultaneous notes)

### DIFF
--- a/api/defaultConfig.json
+++ b/api/defaultConfig.json
@@ -16,6 +16,7 @@
       "enabled": false,
       "noteLength": 0.1
     },
+    "fingerLimit": 11,
     "randomFail": {
       "enabled": false,
       "speed": 5.0,
@@ -165,6 +166,7 @@
       "enabled": false,
       "noteLength": 0.1
     },
+    "fingerLimit": 11,
     "randomFail": {
       "enabled": false,
       "speed": 5.0

--- a/assets/defaultConfig.json
+++ b/assets/defaultConfig.json
@@ -16,6 +16,7 @@
       "enabled": false,
       "noteLength": 0.1
     },
+    "fingerLimit": 11,
     "randomFail": {
       "enabled": false,
       "speed": 5.0,
@@ -165,6 +166,7 @@
       "enabled": false,
       "noteLength": 0.1
     },
+    "fingerLimit": 11,
     "randomFail": {
       "enabled": false,
       "speed": 5.0

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ class App(ctk.CTk):
 
         # WINDOW PROPERTIES
         self.title("nanoMIDIPlayer")
-        self.geometry("600x450")
+        self.geometry("600x490")
         self.resizable(False, False)
 
         if osName == "Windows":

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ class App(ctk.CTk):
 
         # WINDOW PROPERTIES
         self.title("nanoMIDIPlayer")
-        self.geometry("600x490")
+        self.geometry("600x560")
         self.resizable(False, False)
 
         if osName == "Windows":

--- a/modules/functions/midiPlayerFunctions.py
+++ b/modules/functions/midiPlayerFunctions.py
@@ -424,6 +424,35 @@ def decreaseSpeed():
     except Exception as e:
         logger.exception(f"decreaseSpeed error: {e}")
 
+PITCH_OFFSETS = {
+    "Lowest":  -24,
+    "Low":     -12,
+    "Middle":    0,
+    "High":     12,
+    "Highest":  24,
+}
+
+KEY_OFFSETS = {
+    "C": 0, "C#": 1, "D": 2, "D#": 3, "E": 4, "F": 5,
+    "F#": 6, "G": 7, "G#": 8, "A": 9, "A#": 10, "B": 11,
+}
+
+def changePitch(value):
+    logger.info(f"changePitch called: {value}")
+    try:
+        configuration.configData["midiPlayer"]["pitchOffset"] = PITCH_OFFSETS.get(value, 0)
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"changePitch error: {e}")
+
+def changeTranspose(value):
+    logger.info(f"changeTranspose called: {value}")
+    try:
+        configuration.configData["midiPlayer"]["transposeOffset"] = KEY_OFFSETS.get(value, 0)
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"changeTranspose error: {e}")
+
 def increaseSpeed():
     logger.info("increaseSpeed called")
     try:

--- a/modules/functions/settingsFunctions.py
+++ b/modules/functions/settingsFunctions.py
@@ -364,6 +364,28 @@ def changeDrumsDecreaseSize(value):
     except Exception as e:
         logger.exception("Error in changeDrumsDecreaseSize")
 
+def changePianoFingerLimit(value):
+    try:
+        val = int(round(float(value)))
+        configuration.configData["midiPlayer"]["fingerLimit"] = val
+        configuration.configData.save()
+        display = "∞" if val > 10 else str(val)
+        MidiPlayerTab.fingerLimitValueLabel.configure(text=display)
+        logger.debug("PianoFingerLimit changed to %s", val)
+    except Exception as e:
+        logger.exception("Error in changePianoFingerLimit")
+
+def changeDrumsFingerLimit(value):
+    try:
+        val = int(round(float(value)))
+        configuration.configData["drumsMacro"]["fingerLimit"] = val
+        configuration.configData.save()
+        display = "∞" if val > 10 else str(val)
+        DrumsMacroTab.fingerLimitValueLabel.configure(text=display)
+        logger.debug("DrumsFingerLimit changed to %s", val)
+    except Exception as e:
+        logger.exception("Error in changeDrumsFingerLimit")
+
 def changeMidiToQWERTYSustainCutoff(value):
     try:
         val = float(value)

--- a/modules/midiHandler/drumsDarwin.py
+++ b/modules/midiHandler/drumsDarwin.py
@@ -94,15 +94,30 @@ paused = False
 closeThread = False
 playbackSpeed = 1.0
 keyboardHandlers = []
+heldNoteCount = 0
+
+def getDrumsFingerLimit():
+    return int(configuration.configData.get("drumsMacro", {}).get("fingerLimit", 11))
 
 def pressAndMaybeRelease(key):
+    global heldNoteCount
+    limit = getDrumsFingerLimit()
+    if limit <= 10 and heldNoteCount >= limit:
+        log(f"Finger limit ({limit}) reached, skipping drum hit")
+        return
+    heldNoteCount += 1
     press(key)
     if configuration.configData["drumsMacro"]["customHoldLength"]["enabled"]:
-        t = threading.Timer(configuration.configData["drumsMacro"]["customHoldLength"]["noteLength"], lambda: release(key))
+        def _timerRelease():
+            global heldNoteCount
+            release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
+        t = threading.Timer(configuration.configData["drumsMacro"]["customHoldLength"]["noteLength"], _timerRelease)
         timerList.append(t)
         t.start()
 
 def parseMidi(message):
+    global heldNoteCount
     if message.type == 'note_on' and message.velocity > 0:
         key = drumsMap.get(message.note)
         if key is not None:
@@ -111,6 +126,7 @@ def parseMidi(message):
         key = drumsMap.get(message.note)
         if key is not None:
             release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
 
 def playMidiOnce(filePath):
     mid = mido.MidiFile(filePath, clip=True)
@@ -208,9 +224,10 @@ def changeSpeed(amount):
     log(f"Speed: {playbackSpeed * 100:.0f}%")
 
 def stopPlayback():
-    global closeThread, stopEvent, playThread, clockThreadRef, timerList, keyboardHandlers
+    global closeThread, stopEvent, playThread, clockThreadRef, timerList, keyboardHandlers, heldNoteCount
     stopEvent.set()
     closeThread = True
+    heldNoteCount = 0
     for key in list(heldKeys):
         try:
             release(key)

--- a/modules/midiHandler/drumsLinux.py
+++ b/modules/midiHandler/drumsLinux.py
@@ -111,15 +111,30 @@ paused = False
 closeThread = False
 playbackSpeed = 1.0
 keyboardHandlers = []
+heldNoteCount = 0
+
+def getDrumsFingerLimit():
+    return int(configuration.configData.get("drumsMacro", {}).get("fingerLimit", 11))
 
 def pressAndMaybeRelease(key):
+    global heldNoteCount
+    limit = getDrumsFingerLimit()
+    if limit <= 10 and heldNoteCount >= limit:
+        log(f"Finger limit ({limit}) reached, skipping drum hit")
+        return
+    heldNoteCount += 1
     press(key)
     if configuration.configData["drumsMacro"]["customHoldLength"]["enabled"]:
-        t = threading.Timer(configuration.configData["drumsMacro"]["customHoldLength"]["noteLength"], lambda: release(key))
+        def _timerRelease():
+            global heldNoteCount
+            release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
+        t = threading.Timer(configuration.configData["drumsMacro"]["customHoldLength"]["noteLength"], _timerRelease)
         timerList.append(t)
         t.start()
 
 def parseMidi(message):
+    global heldNoteCount
     if message.type == 'note_on' and message.velocity > 0:
         key = drumsMap.get(message.note)
         if key is not None:
@@ -128,6 +143,7 @@ def parseMidi(message):
         key = drumsMap.get(message.note)
         if key is not None:
             release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
 
 def playMidiOnce(filePath):
     mid = mido.MidiFile(filePath, clip=True)
@@ -225,9 +241,10 @@ def changeSpeed(amount):
     log(f"Speed: {playbackSpeed * 100:.0f}%")
 
 def stopPlayback():
-    global closeThread, stopEvent, playThread, clockThreadRef, timerList, keyboardHandlers
+    global closeThread, stopEvent, playThread, clockThreadRef, timerList, keyboardHandlers, heldNoteCount
     stopEvent.set()
     closeThread = True
+    heldNoteCount = 0
     for key in list(heldKeys):
         try:
             release(key)

--- a/modules/midiHandler/drumsWindows.py
+++ b/modules/midiHandler/drumsWindows.py
@@ -111,15 +111,30 @@ paused = False
 closeThread = False
 playbackSpeed = 1.0
 keyboardHandlers = []
+heldNoteCount = 0
+
+def getDrumsFingerLimit():
+    return int(configuration.configData.get("drumsMacro", {}).get("fingerLimit", 11))
 
 def pressAndMaybeRelease(key):
+    global heldNoteCount
+    limit = getDrumsFingerLimit()
+    if limit <= 10 and heldNoteCount >= limit:
+        log(f"Finger limit ({limit}) reached, skipping drum hit")
+        return
+    heldNoteCount += 1
     press(key)
     if configuration.configData["drumsMacro"]["customHoldLength"]["enabled"]:
-        t = threading.Timer(configuration.configData["drumsMacro"]["customHoldLength"]["noteLength"], lambda: release(key))
+        def _timerRelease():
+            global heldNoteCount
+            release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
+        t = threading.Timer(configuration.configData["drumsMacro"]["customHoldLength"]["noteLength"], _timerRelease)
         timerList.append(t)
         t.start()
 
 def parseMidi(message):
+    global heldNoteCount
     if message.type == 'note_on' and message.velocity > 0:
         key = drumsMap.get(message.note)
         if key is not None:
@@ -128,6 +143,7 @@ def parseMidi(message):
         key = drumsMap.get(message.note)
         if key is not None:
             release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
 
 def playMidiOnce(filePath):
     mid = mido.MidiFile(filePath, clip=True)
@@ -225,9 +241,10 @@ def changeSpeed(amount):
     log(f"Speed: {playbackSpeed * 100:.0f}%")
 
 def stopPlayback():
-    global closeThread, stopEvent, playThread, clockThreadRef, timerList, keyboardHandlers
+    global closeThread, stopEvent, playThread, clockThreadRef, timerList, keyboardHandlers, heldNoteCount
     stopEvent.set()
     closeThread = True
+    heldNoteCount = 0
     for key in list(heldKeys):
         try:
             release(key)

--- a/modules/midiHandler/midiDarwin.py
+++ b/modules/midiHandler/midiDarwin.py
@@ -99,6 +99,10 @@ paused = False
 playThread = None
 playbackSpeed = 1.0
 sustainActive = False
+heldNoteCount = 0
+
+def getPianoFingerLimit():
+    return int(configuration.configData.get("midiPlayer", {}).get("fingerLimit", 11))
 
 def findVelocityKey(velocity):
     velocityMap = configuration.configData["midiPlayer"]["pianoMap"]["velocityMap"]
@@ -117,13 +121,21 @@ def findVelocityKey(velocity):
     return velocityMap[str(thresholds[index])]
 
 def pressAndMaybeRelease(key):
+    global heldNoteCount
+    limit = getPianoFingerLimit()
+    if limit <= 10 and heldNoteCount >= limit:
+        log(f"Finger limit ({limit}) reached, skipping note")
+        return
+    heldNoteCount += 1
     press(key)
     if configuration.configData["midiPlayer"]["customHoldLength"]["enabled"]:
-        t = threading.Timer(configuration.configData["midiPlayer"]["customHoldLength"]["noteLength"], lambda: release(key))
+        def _timerRelease():
+            global heldNoteCount
+            release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
+        t = threading.Timer(configuration.configData["midiPlayer"]["customHoldLength"]["noteLength"], _timerRelease)
         timerList.append(t)
         t.start()
-
-def simulateKey(msgType, note, velocity):
     allow88 = configuration.configData["midiPlayer"]["88Keys"]
 
     letterNoteMap = configuration.configData["midiPlayer"]["pianoMap"]["61keyMap"]
@@ -180,6 +192,7 @@ def simulateKey(msgType, note, velocity):
             release("ctrl")
 
     elif msgType == "note_off":
+        global heldNoteCount
         if 36 <= note <= 96:
             if re.search("[!@$%^*(]", key):
                 release(letterNoteMap[str(note - 1)])
@@ -187,10 +200,7 @@ def simulateKey(msgType, note, velocity):
                 release(key.lower())
         else:
             release(key.lower())
-
-def parseMidi(message):
-    global sustainActive
-    if message.type == "control_change" and configuration.configData["midiPlayer"]["sustain"]:
+        heldNoteCount = max(0, heldNoteCount - 1)
         if not sustainActive and message.value > configuration.configData["midiPlayer"]["sustainCutoff"]:
             sustainActive = True
             press("space")
@@ -369,12 +379,13 @@ def changeSpeed(amount):
     log(f"Speed: {playbackSpeed * 100:.0f}%")
 
 def stopPlayback():
-    global closeThread, stopEvent, playThread, clockThreadRef, keyboardHandlers, timerList
+    global closeThread, stopEvent, playThread, clockThreadRef, keyboardHandlers, timerList, heldNoteCount
     if closeThread or stopEvent.is_set():
         return
     
     stopEvent.set()
     closeThread = True
+    heldNoteCount = 0
     for key in list(heldKeys):
         try:
             release(key)

--- a/modules/midiHandler/midiDarwin.py
+++ b/modules/midiHandler/midiDarwin.py
@@ -279,6 +279,9 @@ def playMidiOnce(midiFile):
             continue
         
         if hasattr(msg, "note"):
+            _noteOffset = configuration.configData["midiPlayer"].get("pitchOffset", 0) + configuration.configData["midiPlayer"].get("transposeOffset", 0)
+            if _noteOffset != 0:
+                msg.note += _noteOffset
             if msg.type == "note_on" and msg.velocity > 0:
                 if configuration.configData["midiPlayer"]["randomFail"]["enabled"] and random.random() < configuration.configData["midiPlayer"]["randomFail"]["transpose"] / 100:
                     delta = random.randint(-12, 12)

--- a/modules/midiHandler/midiLinux.py
+++ b/modules/midiHandler/midiLinux.py
@@ -100,6 +100,10 @@ paused = False
 playThread = None
 playbackSpeed = 1.0
 sustainActive = False
+heldNoteCount = 0
+
+def getPianoFingerLimit():
+    return int(configuration.configData.get("midiPlayer", {}).get("fingerLimit", 11))
 
 def findVelocityKey(velocity):
     velocityMap = configuration.configData["midiPlayer"]["pianoMap"]["velocityMap"]
@@ -118,9 +122,19 @@ def findVelocityKey(velocity):
     return velocityMap[str(thresholds[index])]
 
 def pressAndMaybeRelease(key):
+    global heldNoteCount
+    limit = getPianoFingerLimit()
+    if limit <= 10 and heldNoteCount >= limit:
+        log(f"Finger limit ({limit}) reached, skipping note")
+        return
+    heldNoteCount += 1
     press(key)
     if configuration.configData["midiPlayer"]["customHoldLength"]["enabled"]:
-        t = threading.Timer(configuration.configData["midiPlayer"]["customHoldLength"]["noteLength"], lambda: release(key))
+        def _timerRelease():
+            global heldNoteCount
+            release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
+        t = threading.Timer(configuration.configData["midiPlayer"]["customHoldLength"]["noteLength"], _timerRelease)
         timerList.append(t)
         t.start()
 
@@ -181,6 +195,7 @@ def simulateKey(msgType, note, velocity):
             release("ctrl")
 
     elif msgType == "note_off":
+        global heldNoteCount
         if 36 <= note <= 96:
             if re.search("[!@$%^*(]", key):
                 release(letterNoteMap[str(note - 1)])
@@ -188,6 +203,7 @@ def simulateKey(msgType, note, velocity):
                 release(key.lower())
         else:
             release(key.lower())
+        heldNoteCount = max(0, heldNoteCount - 1)
 
 def parseMidi(message):
     global sustainActive
@@ -370,12 +386,13 @@ def changeSpeed(amount):
     log(f"Speed: {playbackSpeed * 100:.0f}%")
 
 def stopPlayback():
-    global closeThread, stopEvent, playThread, clockThreadRef, keyboardHandlers, timerList
+    global closeThread, stopEvent, playThread, clockThreadRef, keyboardHandlers, timerList, heldNoteCount
     if closeThread or stopEvent.is_set():
         return
     
     stopEvent.set()
     closeThread = True
+    heldNoteCount = 0
     for key in list(heldKeys):
         try:
             release(key)

--- a/modules/midiHandler/midiLinux.py
+++ b/modules/midiHandler/midiLinux.py
@@ -139,6 +139,7 @@ def pressAndMaybeRelease(key):
         t.start()
 
 def simulateKey(msgType, note, velocity):
+    note = note + configuration.configData["midiPlayer"].get("pitchOffset", 0) + configuration.configData["midiPlayer"].get("transposeOffset", 0)
     allow88 = configuration.configData["midiPlayer"]["88Keys"]
 
     letterNoteMap = configuration.configData["midiPlayer"]["pianoMap"]["61keyMap"]

--- a/modules/midiHandler/midiPlayer.py
+++ b/modules/midiHandler/midiPlayer.py
@@ -1,0 +1,444 @@
+import customtkinter as ctk
+import tkinter as tk
+
+from modules import configuration
+from ui import customTheme
+from ui.widget.tooltip import ToolTip
+
+class MidiPlayerTab(ctk.CTkFrame):
+    def __init__(self, master):
+        from modules.functions import midiPlayerFunctions
+        from modules.functions import mainFunctions
+        from modules.functions import settingsFunctions
+        super().__init__(master)
+        customTheme.initializeFonts()
+
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+        self.midiFrame = ctk.CTkFrame(
+            self,
+            corner_radius=0,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["BackgroundColor"]
+        )
+
+        self.midiFrame.grid(row=0, column=0, sticky="nsew")
+        self.midiFrame.grid_columnconfigure(0, weight=1)
+
+        self.outputDeviceLabel = ctk.CTkLabel(
+            self.midiFrame, text="MIDI Output Device", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.outputDeviceLabel.grid(row=0, column=0, padx=(0, 200), pady=(10, 0), sticky="s")
+
+        self.midiToggleSwitch = ctk.CTkSwitch(
+            self.midiFrame, text="Use MIDI Output", command=midiPlayerFunctions.switchUseMIDI, variable=midiPlayerFunctions.switchUseMIDIvar, font=customTheme.globalFont14, 
+            onvalue="on", offvalue="off", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchDisabled"], 
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchEnabled"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircle"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircleHovered"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.midiToggleSwitch.grid(row=0, column=0, padx=(0, 40), pady=(10, 0), sticky="e")
+        ToolTip.CreateToolTip(self.midiToggleSwitch, text = 'Simulates MIDI signals to the\nselected MIDI Output Device\n\nNOTE: Having this enabled won\'t simulate\nQWERTY Keys for you if you\'re looking to macro.')
+
+        self.outputDeviceDropdown = ctk.CTkOptionMenu(
+            self.midiFrame, width=315, values=["Loading..."], font=customTheme.globalFont14, 
+            dropdown_font=customTheme.globalFont14, command=None, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionBackColor"], 
+            dropdown_fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownBackground"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonColor"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.outputDeviceDropdown.grid(row=1, column=0, padx=(0,35), pady=0)
+        self.__class__.outputDeviceDropdown = self.outputDeviceDropdown
+        self.__class__.midiToggleSwitch = self.midiToggleSwitch
+        ToolTip.CreateToolTip(self.outputDeviceDropdown, text = 'Selected MIDI Output Device')
+
+        self.refreshOutputDevices = ctk.CTkButton(
+            self.midiFrame, image=customTheme.resetImageCTk, text="", width=30, command=mainFunctions.refreshOutputDevices, 
+            font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.refreshOutputDevices.grid(row=1, column=0, padx=(320, 0), pady=(0, 0))
+        ToolTip.CreateToolTip(self.refreshOutputDevices, text = 'Refresh MIDI Output Devices List')
+
+        # MIDI FILE SELECTION
+        self.filePathLabel = ctk.CTkLabel(
+            self.midiFrame, text="MIDI File Path", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.filePathLabel.grid(row=2, column=0, padx=(0,200), pady=(10, 0))
+
+        self.filePathEntry = ctk.CTkOptionMenu(
+            self.midiFrame, width=350, values="", command=midiPlayerFunctions.switchMidiEvent, font=customTheme.globalFont14, 
+            dropdown_font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionBackColor"], 
+            dropdown_fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownBackground"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonColor"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.filePathEntry.grid(row=3, column=0, padx=20, pady=(10, 0))
+        self.__class__.filePathEntry = self.filePathEntry
+        ToolTip.CreateToolTip(self.filePathEntry, text = 'Selected MIDI File')
+
+        self.selectFileButton = ctk.CTkButton(
+            self.midiFrame, text="Select File", command=midiPlayerFunctions.selectFile, font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.selectFileButton.grid(row=2, column=0, padx=(0,55), pady=(10,0), sticky="e")
+        ToolTip.CreateToolTip(self.selectFileButton, text = 'Select MIDI File (.mid | .midi)')
+
+        # CONSOLE
+        self.consoleFrame = tk.Frame(
+            master=self.midiFrame, width=200, height=155, 
+            bg=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ConsoleBackground"]
+        )
+        self.consoleFrame.grid(row=4, column=0, padx=(0,40), pady=(10,5), sticky="ne")
+        self.consoleFrame.pack_propagate(0)
+        self.__class__.consoleFrame = self.consoleFrame
+
+        # HOTKEYS
+        self.playHotkeyLabel = ctk.CTkLabel(
+            self.midiFrame, text=" Play:", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.playHotkeyLabel.grid(row=4, column=0, padx=(0, 300), pady=(0, 0), sticky="s")
+
+        self.playHotkeyButton = ctk.CTkButton(
+            self.midiFrame, text=configuration.configData["hotkeys"].get('play', 'f1').upper(), width=70, command=mainFunctions.playHotkeyCommand, 
+            font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.playHotkeyButton.grid(row=4, column=0, padx=(0, 165), pady=(0, 0), sticky="s")
+        self.__class__.playHotkeyButton = self.playHotkeyButton
+        ToolTip.CreateToolTip(self.playHotkeyButton, text = 'Start Playback Hotkey')
+
+        self.pauseHotkeyLabel = ctk.CTkLabel(
+            self.midiFrame, text="Pause:", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.pauseHotkeyLabel.grid(row=5, column=0, padx=(0, 300), pady=(2, 30), sticky="s")
+
+        self.pauseHotkeyButton = ctk.CTkButton(
+            self.midiFrame, text=configuration.configData["hotkeys"].get('pause', 'f2').upper(), width=70, command=mainFunctions.pauseHotkeyCommand, 
+            font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.pauseHotkeyButton.grid(row=5, column=0, padx=(0, 165), pady=(0, 30), sticky="s")
+        self.__class__.pauseHotkeyButton = self.pauseHotkeyButton
+        ToolTip.CreateToolTip(self.pauseHotkeyButton, text = 'Pause Playback Hotkey')
+
+        self.stopHotkeyLabel = ctk.CTkLabel(
+            self.midiFrame, text=" Stop:", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.stopHotkeyLabel.grid(row=5, column=0, padx=(0, 300), pady=(0, 0), sticky="s")
+
+        self.stopHotkeyButton = ctk.CTkButton(
+            self.midiFrame, text=configuration.configData["hotkeys"].get('stop', 'f3').upper(), width=70, command=mainFunctions.stopHotkeyCommand, 
+            font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.stopHotkeyButton.grid(row=5, column=0, padx=(0, 165), pady=(0, 0), sticky="s")
+        self.__class__.stopHotkeyButton = self.stopHotkeyButton
+        ToolTip.CreateToolTip(self.stopHotkeyButton, text = 'Stop Playback Hotkey')
+
+        self.slowDownHotkeyLabel = ctk.CTkLabel(
+            self.midiFrame, text="Slow Down:", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.slowDownHotkeyLabel.grid(row=5, column=0, padx=(80, 0), pady=(0, 30), sticky="s")
+
+        self.speedUpHotkeyButton = ctk.CTkButton(
+            self.midiFrame, text=configuration.configData["hotkeys"].get('speedup', 'f4').upper(), width=70, command=mainFunctions.speedUpHotkeyCommand, 
+            font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.speedUpHotkeyButton.grid(row=5, column=0, padx=(250, 0), pady=(0, 30), sticky="s")
+        self.__class__.speedUpHotkeyButton = self.speedUpHotkeyButton
+        ToolTip.CreateToolTip(self.speedUpHotkeyButton, text = 'Speed-up Playback Hotkey')
+
+        self.speedUpHotkeyLabel = ctk.CTkLabel(
+            self.midiFrame, text=" Speed Up:", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.speedUpHotkeyLabel.grid(row=5, column=0, padx=(80, 0), pady=(0, 0), sticky="s")
+
+        self.slowHotkeyButton = ctk.CTkButton(
+            self.midiFrame, text=configuration.configData["hotkeys"].get('slowdown', 'f5').upper(), width=70, command=mainFunctions.slowHotkeyCommand, 
+            font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["HotkeySelectorHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.slowHotkeyButton.grid(row=5, column=0, padx=(250, 0), pady=(0, 0), sticky="s")
+        self.__class__.slowHotkeyButton = self.slowHotkeyButton
+        ToolTip.CreateToolTip(self.slowHotkeyButton, text = 'Slow-down Playback Hotkey')
+        
+        # TOGGLES
+        self.sustainToggle = ctk.CTkSwitch(
+            self.midiFrame, text="Sustain   ", command=midiPlayerFunctions.switchSustain, variable=midiPlayerFunctions.switchSustainvar, font=customTheme.globalFont14, 
+            onvalue="on", offvalue="off", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchDisabled"], 
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchEnabled"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircle"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircleHovered"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.sustainToggle.grid(row=4, column=0, padx=(40, 0), pady=(10, 0), sticky="nw")
+        self.__class__.sustainToggle = self.sustainToggle
+        ToolTip.CreateToolTip(self.sustainToggle, text = 'Simulates Pedal by "Spacebar"\nOnly works on supported games.')
+
+        self.noDoublesToggle = ctk.CTkSwitch(
+            self.midiFrame, text="No Doubles", command=midiPlayerFunctions.switchNoDoubles, variable=midiPlayerFunctions.switchNoDoublesvar, font=customTheme.globalFont14, 
+            onvalue="on", offvalue="off", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchDisabled"], 
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchEnabled"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircle"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircleHovered"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.noDoublesToggle.grid(row=4, column=0, padx=(40, 0), pady=(40, 0), sticky="nw")
+        self.__class__.noDoublesToggle = self.noDoublesToggle
+        ToolTip.CreateToolTip(self.noDoublesToggle, text = 'Prevents double-triggering of keys')
+
+        self.velocityToggle = ctk.CTkSwitch(
+            self.midiFrame, text="Velocity  ", command=midiPlayerFunctions.switchVelocity, variable=midiPlayerFunctions.switchVelocityvar, font=customTheme.globalFont14, 
+            onvalue="on", offvalue="off", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchDisabled"], 
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchEnabled"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircle"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircleHovered"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.velocityToggle.grid(row=4, column=0, padx=(40, 0), pady=(70, 0), sticky="nw")
+        self.__class__.velocityToggle = self.velocityToggle
+        ToolTip.CreateToolTip(self.velocityToggle, text = 'Simulates how hard a key is pressed by "CTRL"\nwhich affects the loudness of that note\nOnly works on supported games.')
+
+        self.use88KeysToggle = ctk.CTkSwitch(
+            self.midiFrame, text="88 Keys   ", command=midiPlayerFunctions.switch88Keys, variable=midiPlayerFunctions.switch88Keysvar, font=customTheme.globalFont14, 
+            onvalue="on", offvalue="off", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchDisabled"], 
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchEnabled"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircle"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SwitchCircleHovered"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.use88KeysToggle.grid(row=4, column=0, padx=(40, 0), pady=(100, 10), sticky="nw")
+        self.__class__.use88KeysToggle = self.use88KeysToggle
+        ToolTip.CreateToolTip(self.use88KeysToggle, text = 'Simulate LowNote and HighNote by "CTRL"\nOnly works on supported games.')
+
+        # PITCH & KEY TRANSPOSE DROPDOWNS
+        _initPitchOffset = configuration.configData.get("midiPlayer", {}).get("pitchOffset", 0)
+        _pitchOffsetMap = {-24: "Lowest", -12: "Low", 0: "Middle", 12: "High", 24: "Highest"}
+        _initPitchLabel = _pitchOffsetMap.get(_initPitchOffset, "Middle")
+
+        _initTransposeOffset = configuration.configData.get("midiPlayer", {}).get("transposeOffset", 0)
+        _keyNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+        _initKeyLabel = _keyNames[_initTransposeOffset % 12] if 0 <= _initTransposeOffset <= 11 else "C"
+
+        self.pitchLabel = ctk.CTkLabel(
+            self.midiFrame, text="Pitch", fg_color="transparent", font=customTheme.globalFont14,
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.pitchLabel.grid(row=6, column=0, padx=(0, 210), pady=(10, 0))
+
+        self.pitchDropdown = ctk.CTkOptionMenu(
+            self.midiFrame, width=130, values=["Lowest", "Low", "Middle", "High", "Highest"],
+            font=customTheme.globalFont14, dropdown_font=customTheme.globalFont14,
+            command=midiPlayerFunctions.changePitch,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionBackColor"],
+            dropdown_fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownBackground"],
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonColor"],
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonHoverColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.pitchDropdown.set(_initPitchLabel)
+        self.pitchDropdown.grid(row=7, column=0, padx=(0, 60), pady=(4, 10))
+        self.__class__.pitchDropdown = self.pitchDropdown
+        ToolTip.CreateToolTip(self.pitchDropdown, text='Shift playback pitch by octaves\nLowest=-2oct  Low=-1oct  Middle=default\nHigh=+1oct  Highest=+2oct')
+
+        self.keyTransposeLabel = ctk.CTkLabel(
+            self.midiFrame, text="Key", fg_color="transparent", font=customTheme.globalFont14,
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.keyTransposeLabel.grid(row=6, column=0, padx=(130, 0), pady=(10, 0))
+
+        self.keyTransposeDropdown = ctk.CTkOptionMenu(
+            self.midiFrame, width=80,
+            values=["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"],
+            font=customTheme.globalFont14, dropdown_font=customTheme.globalFont14,
+            command=midiPlayerFunctions.changeTranspose,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionBackColor"],
+            dropdown_fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownBackground"],
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonColor"],
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonHoverColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.keyTransposeDropdown.set(_initKeyLabel)
+        self.keyTransposeDropdown.grid(row=7, column=0, padx=(230, 0), pady=(4, 10))
+        self.__class__.keyTransposeDropdown = self.keyTransposeDropdown
+        ToolTip.CreateToolTip(self.keyTransposeDropdown, text='Transpose playback by semitones\nC = no transpose (default)')
+
+        # PLAYBACK BUTTONS
+        self.playButton = ctk.CTkButton(
+            self.midiFrame, text="Play", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayColor"], 
+            width=80, command=midiPlayerFunctions.playButton, font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayColorHover"]
+        )
+        self.playButton.grid(row=10, column=0, padx=45, pady=(0, 0), sticky="w")
+        self.__class__.playButton = self.playButton
+        ToolTip.CreateToolTip(self.playButton, text = 'Start Playback')
+
+        self.stopButton = ctk.CTkButton(
+            self.midiFrame, text="Stop", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["StopColorDisabled"], 
+            width=80, state="disabled", command=midiPlayerFunctions.stopPlayback, font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["StopColorHover"]
+        )
+        self.stopButton.grid(row=10, column=0, padx=130, pady=(0, 0), sticky="w")
+        self.__class__.stopButton = self.stopButton
+
+        # TIMER
+        self.timelineText = "0:00:00 / 0:00:00" if configuration.configData['appUI']['timestamp'] else "X:XX:XX / 0:00:00"
+
+        self.timelineIndicator = ctk.CTkLabel(
+            self.midiFrame, text=self.timelineText, fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.timelineIndicator.grid(row=10, column=0, padx=(0, 50), pady=(0, 0), sticky="e")
+        self.__class__.timelineIndicator = self.timelineIndicator
+
+        # FINGER LIMIT
+        _pianoInitLimit = configuration.configData.get("midiPlayer", {}).get("fingerLimit", 11)
+        _pianoInitDisplay = "∞" if _pianoInitLimit > 10 else str(_pianoInitLimit)
+
+        self.fingerLimitLabel = ctk.CTkLabel(
+            self.midiFrame, text="Fingers", fg_color="transparent", font=customTheme.globalFont14,
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.fingerLimitLabel.grid(row=8, column=0, padx=(0, 290), pady=(5, 0))
+
+        self.fingerLimitSlider = ctk.CTkSlider(
+            self.midiFrame, from_=1, to=11, number_of_steps=10, width=190,
+            command=lambda value: settingsFunctions.changePianoFingerLimit(value),
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderBackColor"],
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderFillColor"],
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderCircleColor"],
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderCircleHoverColor"]
+        )
+        self.fingerLimitSlider.grid(row=8, column=0, padx=(0, 50), pady=(5, 0))
+        self.fingerLimitSlider.set(_pianoInitLimit)
+        self.__class__.fingerLimitSlider = self.fingerLimitSlider
+        ToolTip.CreateToolTip(self.fingerLimitSlider, text='Max simultaneous keys (1-10)\nSlide past 10 for No Limit (∞)')
+
+        self.fingerLimitValueLabel = ctk.CTkLabel(
+            self.midiFrame, text=_pianoInitDisplay, width=50, font=customTheme.globalFont14,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedValueBoxBackColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            corner_radius=6
+        )
+        self.fingerLimitValueLabel.grid(row=8, column=0, padx=(200, 0), pady=(5, 0))
+        self.__class__.fingerLimitValueLabel = self.fingerLimitValueLabel
+
+        self.resetFingerLimitButton = ctk.CTkButton(
+            self.midiFrame, image=customTheme.resetImageCTk, text="", width=30,
+            command=lambda: (self.fingerLimitSlider.set(11), settingsFunctions.changePianoFingerLimit(11)),
+            font=customTheme.globalFont14,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonColor"],
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonHoverColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.resetFingerLimitButton.grid(row=8, column=0, padx=(290, 0), pady=(5, 0))
+        ToolTip.CreateToolTip(self.resetFingerLimitButton, text='Reset Finger Limit to ∞')
+
+        # SPEED CONTROL
+        self.speedTextTitle = ctk.CTkLabel(
+            self.midiFrame, text="Speed", fg_color="transparent", font=customTheme.globalFont14, 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.speedTextTitle.grid(row=9, column=0, padx=(0,290), pady=(5, 0))
+
+        self.speedSlider = ctk.CTkSlider(
+            self.midiFrame, from_=1, to=500, command=lambda value: settingsFunctions.updateFromSlider("midiSpeedController", value), 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderBackColor"], width=190,
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderFillColor"], 
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderCircleColor"], 
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderCircleHoverColor"]
+        )
+        self.speedSlider.grid(row=9, column=0, padx=(0,50), pady=(5, 0))
+        self.__class__.speedSlider = self.speedSlider
+        self.speedSlider.set(100)
+        ToolTip.CreateToolTip(self.speedSlider, text = 'Playback Speed')
+
+        self.resetSpeedButton = ctk.CTkButton(
+            self.midiFrame, image=customTheme.resetImageCTk, text="", width=30, command=lambda: settingsFunctions.resetControl("midiSpeedController"), 
+            font=customTheme.globalFont14, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonColor"], 
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonHoverColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"], 
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.resetSpeedButton.grid(row=9, column=0, padx=(290, 0), pady=(5, 0))
+        ToolTip.CreateToolTip(self.resetSpeedButton, text = 'Reset Speed')
+
+        self.speedValueEntry = ctk.CTkEntry(
+            self.midiFrame, placeholder_text="100", width=50, 
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedValueBoxBackColor"], 
+            font=customTheme.globalFont14, 
+            border_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedValueBoxBorderColor"], 
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"]
+        )
+        self.speedValueEntry.grid(row=9, column=0, padx=(200,0), pady=(5, 0))
+        self.__class__.speedValueEntry = self.speedValueEntry
+        self.speedValueEntry.insert(0, "100")
+        ToolTip.CreateToolTip(self.speedValueEntry, text = 'Speed Value')
+
+        self.speedValueEntry.bind("<FocusOut>", lambda value: settingsFunctions.updateFromEntry("midiSpeedController", value))
+        self.speedValueEntry.bind("<KeyRelease>", lambda value: settingsFunctions.updateFromEntry("midiSpeedController", value))
+        self.speedSlider.bind("<ButtonRelease-1>", lambda value: settingsFunctions.updateFromEntry("midiSpeedController", value))
+
+        mainFunctions.insertConsoleText("Hello! :)", ignoreConsoleCheck=False)

--- a/modules/midiHandler/midiPlayerFunctions.py
+++ b/modules/midiHandler/midiPlayerFunctions.py
@@ -1,0 +1,474 @@
+import threading
+import json
+import customtkinter
+import os
+import platform
+import datetime
+import keyboard
+import logging
+
+from tkinter import filedialog
+from mido import MidiFile
+from pynput import keyboard as pynputKeyboard
+from modules import configuration
+
+from ui.midiPlayer import MidiPlayerTab
+from ui.settings import SettingsTab
+from ui import customTheme
+from modules.functions import mainFunctions
+from modules.midiHandler import useOutput
+
+logger = logging.getLogger(__name__)
+osName = platform.system()
+
+if osName == 'Windows':
+    from modules.midiHandler import midiWindows as midiHandler
+elif osName == 'Darwin':
+    from modules.midiHandler import midiDarwin as midiHandler
+elif osName == "Linux":
+    from modules.midiHandler import midiLinux as midiHandler
+
+app = mainFunctions.getApp()
+
+switchUseMIDIvar = customtkinter.StringVar(value="off")
+switchSustainvar = customtkinter.StringVar(value="off")
+switchNoDoublesvar = customtkinter.StringVar(value="off")
+switchVelocityvar = customtkinter.StringVar(value="off")
+switch88Keysvar = customtkinter.StringVar(value="off")
+
+switchUseMIDIvar.set("on" if configuration.configData.get('midiPlayer', {}).get('useMIDIOutput', False) else "off")
+switchSustainvar.set("on" if configuration.configData.get('midiPlayer', {}).get('sustain', False) else "off")
+switchNoDoublesvar.set("on" if configuration.configData.get('midiPlayer', {}).get('noDoubles', False) else "off")
+switchVelocityvar.set("on" if configuration.configData.get('midiPlayer', {}).get('velocity', False) else "off")
+switch88Keysvar.set("on" if configuration.configData.get('midiPlayer', {}).get('88Keys', False) else "off")
+
+def switchUseMIDI():
+    logger.info("switchUseMIDI called")
+    try:
+        configuration.configData["midiPlayer"]['useMIDIOutput'] = switchUseMIDIvar.get() == "on"
+        configuration.configData.save()
+
+        mainFunctions.clearConsole()
+        mainFunctions.refreshOutputDevices()
+        if switchUseMIDIvar.get() == "on":
+            threading.Thread(target=mainFunctions.insertConsoleText, args=("-------< WARNING >-------   This will not press keys for you!", True)).start()
+        else:
+            threading.Thread(target=mainFunctions.insertConsoleText, args=("Macro Mode.", True)).start()
+    except Exception as e:
+        logger.exception(f"switchUseMIDI error: {e}")
+
+def switchSustain():
+    logger.info("switchSustain called")
+    try:
+        configuration.configData['midiPlayer']['sustain'] = switchSustainvar.get() == "on"
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"switchSustain error: {e}")
+
+def switchNoDoubles():
+    logger.info("switchNoDoubles called")
+    try:
+        configuration.configData['midiPlayer']['noDoubles'] = switchNoDoublesvar.get() == "on"
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"switchNoDoubles error: {e}")
+
+def switchVelocity():
+    logger.info("switchVelocity called")
+    try:
+        configuration.configData['midiPlayer']['velocity'] = switchVelocityvar.get() == "on"
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"switchVelocity error: {e}")
+
+def switch88Keys():
+    logger.info("switch88Keys called")
+    try:
+        configuration.configData['midiPlayer']['88Keys'] = switch88Keysvar.get() == "on"
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"switch88Keys error: {e}")
+
+def selectFile():
+    logger.info("selectFile called")
+    try:
+        MidiPlayerTab.filePathEntry.set("")
+        unbindControls()
+        stopPlayback()
+        MidiPlayerTab.timelineIndicator.configure(text="0:00:00 / 0:00:00")
+        MidiPlayerTab.playButton.configure(text="Play")
+
+        filePath = filedialog.askopenfilename(filetypes=[("MIDI files", "*.mid"), ("MIDI files", "*.midi")])
+        logger.debug(f"filePath selected: {filePath}")
+        if filePath:
+            currentVAL = list(MidiPlayerTab.filePathEntry.cget("values"))
+            if filePath not in currentVAL:
+                currentVAL.append(filePath)
+                MidiPlayerTab.filePathEntry.configure(values=currentVAL)
+
+            MidiPlayerTab.filePathEntry.set(filePath)
+            midiFile = MidiFile(filePath, clip=True)
+
+            time = midiFile.length
+            timelineText = (
+                f"0:00:00 / {str(datetime.timedelta(seconds=int(time)))}"
+                if configuration.configData['appUI']['timestamp']
+                else f"X:XX:XX / {str(datetime.timedelta(seconds=int(time)))}"
+            )
+            MidiPlayerTab.timelineIndicator.configure(text=timelineText)
+
+            configuration.configData['midiPlayer']['currentFile'] = filePath
+
+            if 'midiList' not in configuration.configData['midiPlayer']:
+                configuration.configData['midiPlayer']['midiList'] = []
+            if filePath not in configuration.configData['midiPlayer']['midiList']:
+                configuration.configData['midiPlayer']['midiList'].append(filePath)
+            configuration.configData.save()
+
+            bindControls()
+    except Exception as e:
+        logger.exception(f"selectFile error: {e}")
+
+def loadSavedFile():
+    logger.info("loadSavedFile called")
+    try:
+        midiList = configuration.configData['midiPlayer'].get('midiList', [])
+        currentFile = configuration.configData['midiPlayer'].get('currentFile', '')
+        
+        midiList = [f for f in midiList if os.path.exists(f)]
+        configuration.configData['midiPlayer']['midiList'] = midiList
+        
+        if currentFile and not os.path.exists(currentFile):
+            currentFile = ""
+            configuration.configData['midiPlayer']['currentFile'] = ""
+        
+        configuration.configData.save()
+        
+        entryValues = list(MidiPlayerTab.filePathEntry.cget("values"))
+        
+        downloadFolder = os.path.join(configuration.baseDirectory, "Midis")
+        if os.path.exists(downloadFolder):
+            for filename in os.listdir(downloadFolder):
+                if filename.lower().endswith(('.mid', '.midi')):
+                    filePath = os.path.join(downloadFolder, filename)
+                    if filePath not in entryValues and filePath not in midiList:
+                        entryValues.append(filePath)
+        
+        for p in midiList:
+            if p not in entryValues:
+                entryValues.append(p)
+        
+        MidiPlayerTab.filePathEntry.configure(values=entryValues)
+        
+        if currentFile:
+            if currentFile not in entryValues:
+                entryValues.append(currentFile)
+                MidiPlayerTab.filePathEntry.configure(values=entryValues)
+            MidiPlayerTab.filePathEntry.set(currentFile)
+            midiFileData = MidiFile(currentFile, clip=True)
+            totalTime = midiFileData.length
+            timelineText = f"0:00:00 / {str(datetime.timedelta(seconds=int(totalTime)))}" if configuration.configData['appUI']['timestamp'] else f"X:XX:XX / {str(datetime.timedelta(seconds=int(totalTime)))}"
+            MidiPlayerTab.timelineIndicator.configure(text=timelineText)
+            logger.debug(f"loaded currentFile: {currentFile}")
+            return
+        
+        if midiList:
+            firstFile = midiList[0]
+            MidiPlayerTab.filePathEntry.set(firstFile)
+            configuration.configData['midiPlayer']['currentFile'] = firstFile
+            configuration.configData.save()
+            midiFileData = MidiFile(firstFile, clip=True)
+            totalTime = midiFileData.length
+            timelineText = f"0:00:00 / {str(datetime.timedelta(seconds=int(totalTime)))}" if configuration.configData['appUI']['timestamp'] else f"X:XX:XX / {str(datetime.timedelta(seconds=int(totalTime)))}"
+            MidiPlayerTab.timelineIndicator.configure(text=timelineText)
+            logger.debug(f"loaded firstFile: {firstFile}")
+            return
+        
+        MidiPlayerTab.filePathEntry.set("None")
+        MidiPlayerTab.timelineIndicator.configure(text="0:00:00 / 0:00:00")
+        logger.debug("no saved files found")
+    except Exception as e:
+        logger.exception(f"loadSavedFile error: {e}")
+
+def switchMidiEvent(event=None):
+    logger.info("switchMidiEvent called")
+    try:
+        midiFile = MidiPlayerTab.filePathEntry.get()
+        configuration.configData['midiPlayer']['currentFile'] = midiFile
+        configuration.configData.save()
+
+        midiFileData = MidiFile(midiFile, clip=True)
+        totalTime = midiFileData.length
+        timelineText = f"0:00:00 / {str(datetime.timedelta(seconds=int(totalTime)))}" if configuration.configData['appUI']['timestamp'] else f"X:XX:XX / {str(datetime.timedelta(seconds=int(totalTime)))}"
+        MidiPlayerTab.timelineIndicator.configure(text=timelineText)
+        bindControls()
+        logger.debug(f"switched midi file to: {midiFile}")
+    except Exception as e:
+        logger.exception(f"switchMidiEvent error: {e}")
+
+def bindControls():
+    try:
+        playKey = configuration.configData["hotkeys"].get("play", "F1").upper()
+        pauseKey = configuration.configData["hotkeys"].get("pause", "F2").upper()
+        stopKey = configuration.configData["hotkeys"].get("stop", "F3").upper()
+        speedUpKey = configuration.configData["hotkeys"].get("speedup", "F4").upper()
+        slowDownKey = configuration.configData["hotkeys"].get("slowdown", "F5").upper()
+
+        if osName == "Windows":
+            unbindControls()
+            midiHandler.keyboardHandlers.append(keyboard.on_press_key(playKey.lower(), lambda e: startPlayback()))
+            midiHandler.keyboardHandlers.append(keyboard.on_press_key(pauseKey.lower(), lambda e: pausePlayback()))
+            midiHandler.keyboardHandlers.append(keyboard.on_press_key(stopKey.lower(), lambda e: stopPlayback()))
+            midiHandler.keyboardHandlers.append(keyboard.on_press_key(speedUpKey.lower(), lambda e: decreaseSpeed()))
+            midiHandler.keyboardHandlers.append(keyboard.on_press_key(slowDownKey.lower(), lambda e: increaseSpeed()))
+        else:
+            from modules.functions import mainFunctions
+            mainFunctions.activeHotkeys.clear()
+            mainFunctions.activeHotkeys.update({
+                playKey: startPlayback,
+                pauseKey: pausePlayback,
+                stopKey: stopPlayback,
+                speedUpKey: decreaseSpeed,
+                slowDownKey: increaseSpeed
+            })
+            mainFunctions.startGlobalListener()
+    except Exception as e:
+        logger.exception(f"bindControls error: {e}")
+
+def unbindControls():
+    try:
+        if osName == "Windows":
+            for h in list(midiHandler.keyboardHandlers):
+                try:
+                    keyboard.unhook(h)
+                except Exception:
+                    pass
+            midiHandler.keyboardHandlers.clear()
+        else:
+            from modules.functions import mainFunctions
+            mainFunctions.activeHotkeys.clear()
+    except Exception as e:
+        logger.exception(f"unbindControls error: {e}")
+
+def playButton():
+    logger.info("playButton called")
+    try:
+        if not app.isRunning:
+            startPlayback()
+        else:
+            pausePlayback()
+    except Exception as e:
+        logger.exception(f"playButton error: {e}")
+
+def startPlayback():
+    logger.info("startPlayback called")
+    try:
+        midiFile = MidiPlayerTab.filePathEntry.get()
+        logger.debug(f"startPlayback midiFile: {midiFile}")
+        if not os.path.exists(midiFile):
+            logger.warning("MIDI File does not exist.")
+            threading.Thread(target=mainFunctions.insertConsoleText, args=("MIDI File does not exist.", True)).start()
+            return
+
+        useMIDI = configuration.configData["midiPlayer"]['useMIDIOutput']
+
+        if useMIDI:
+            outputDevice = MidiPlayerTab.outputDeviceDropdown.get()
+            logger.debug(f"outputDevice selected: {outputDevice}")
+            if not outputDevice:
+                threading.Thread(target=mainFunctions.insertConsoleText, args=("No MIDI output device selected.", True)).start()
+                return
+
+            app.isRunning = True
+            MidiPlayerTab.playButton.configure(
+                text="Playing",
+                fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayingColor"],
+                hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayingColorHover"]
+            )
+            MidiPlayerTab.stopButton.configure(state="normal", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["StopColor"])
+
+            def updateTimeline(text):
+                MidiPlayerTab.timelineIndicator.after(0, lambda: MidiPlayerTab.timelineIndicator.configure(text=text))
+
+            useOutput.startPlayback(midiFile, outputDevice, updateCallback=updateTimeline)
+            logger.debug("useOutput.startPlayback called")
+
+        elif app and not app.isRunning:
+            app.isRunning = True
+            MidiPlayerTab.playButton.configure(
+                text="Playing",
+                fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayingColor"],
+                hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayingColorHover"]
+            )
+            MidiPlayerTab.stopButton.configure(state="normal", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["StopColor"])
+
+            def updateTimeline(text):
+                MidiPlayerTab.timelineIndicator.after(0, lambda: MidiPlayerTab.timelineIndicator.configure(text=text))
+
+            midiHandler.startPlayback(midiFile, updateCallback=updateTimeline)
+            logger.debug("midiHandler.startPlayback called")
+    except Exception as e:
+        logger.exception(f"startPlayback error: {e}")
+
+def stopPlayback():
+    logger.info("stopPlayback called")
+    try:
+        if not app.isRunning:
+            return
+
+        useMIDI = configuration.configData["midiPlayer"]["useMIDIOutput"]
+
+        if useMIDI:
+            useOutput.stopPlayback()
+            logger.debug("useOutput.stopPlayback called")
+        else:
+            midiHandler.stopPlayback()
+            logger.debug("midiHandler.stopPlayback called")
+
+        app.isRunning = False
+        bindControls()
+        MidiPlayerTab.stopButton.configure(
+            state="disabled",
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["StopColorDisabled"]
+        )
+        MidiPlayerTab.playButton.configure(
+            text="Play",
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayColor"],
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayColorHover"]
+        )
+
+        midiFile = MidiPlayerTab.filePathEntry.get()
+        if os.path.exists(midiFile):
+            midiFileData = MidiFile(midiFile, clip=True)
+            totalTime = midiFileData.length
+            timelineText = (
+                f"0:00:00 / {str(datetime.timedelta(seconds=int(totalTime)))}"
+                if configuration.configData['appUI']['timestamp']
+                else f"X:XX:XX / {str(datetime.timedelta(seconds=int(totalTime)))}"
+            )
+            MidiPlayerTab.timelineIndicator.configure(text=timelineText)
+        logger.debug("stopPlayback completed")
+    except Exception as e:
+        logger.exception(f"stopPlayback error: {e}")
+
+def pausePlayback():
+    logger.info("pausePlayback called")
+    try:
+        if not app.isRunning:
+            return
+
+        useMIDI = configuration.configData["midiPlayer"]["useMIDIOutput"]
+        paused = False
+
+        if useMIDI:
+            useOutput.pausePlayback()
+            paused = useOutput.paused
+            logger.debug(f"useOutput.paused: {paused}")
+        else:
+            midiHandler.pausePlayback()
+            paused = midiHandler.paused
+            logger.debug(f"midiHandler.paused: {paused}")
+
+        if paused:
+            MidiPlayerTab.playButton.configure(
+                text="Paused",
+                fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PausedColor"],
+                hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PausedColorHover"]
+            )
+        else:
+            MidiPlayerTab.playButton.configure(
+                text="Playing",
+                fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayingColor"],
+                hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayingColorHover"]
+            )
+        logger.debug("pausePlayback state updated")
+    except Exception as e:
+        logger.exception(f"pausePlayback error: {e}")
+
+def setSpeed(speed):
+    logger.info(f"setSpeed called with speed: {speed}")
+    try:
+        useMIDI = configuration.configData["midiPlayer"]["useMIDIOutput"]
+
+        if useMIDI:
+            useOutput.playbackSpeed = max(0.01, min(5.0, speed / 100.0))
+            app.playbackSpeed = round(useOutput.playbackSpeed * 100)
+        else:
+            midiHandler.playbackSpeed = max(0.01, min(5.0, speed / 100.0))
+            app.playbackSpeed = round(midiHandler.playbackSpeed * 100)
+
+        MidiPlayerTab.speedSlider.set(app.playbackSpeed)
+        MidiPlayerTab.speedValueEntry.delete(0, "end")
+        MidiPlayerTab.speedValueEntry.insert(0, str(app.playbackSpeed))
+        logger.debug(f"playbackSpeed set to: {app.playbackSpeed}")
+    except Exception as e:
+        logger.exception(f"setSpeed error: {e}")
+
+def decreaseSpeed():
+    logger.info("decreaseSpeed called")
+    try:
+        useMIDI = configuration.configData["midiPlayer"]["useMIDIOutput"]
+        app.focus_set()
+
+        if useMIDI:
+            useOutput.changeSpeed(-(configuration.configData["midiPlayer"]["decreaseSize"] / 100))
+            app.playbackSpeed = round(useOutput.playbackSpeed * 100)
+        else:
+            midiHandler.changeSpeed(-(configuration.configData["midiPlayer"]["decreaseSize"] / 100))
+            app.playbackSpeed = round(midiHandler.playbackSpeed * 100)
+
+        MidiPlayerTab.speedSlider.set(app.playbackSpeed)
+        MidiPlayerTab.speedValueEntry.delete(0, "end")
+        MidiPlayerTab.speedValueEntry.insert(0, str(app.playbackSpeed))
+        logger.debug(f"decreased playbackSpeed to: {app.playbackSpeed}")
+    except Exception as e:
+        logger.exception(f"decreaseSpeed error: {e}")
+
+PITCH_OFFSETS = {
+    "Lowest":  -24,
+    "Low":     -12,
+    "Middle":    0,
+    "High":     12,
+    "Highest":  24,
+}
+
+KEY_OFFSETS = {
+    "C": 0, "C#": 1, "D": 2, "D#": 3, "E": 4, "F": 5,
+    "F#": 6, "G": 7, "G#": 8, "A": 9, "A#": 10, "B": 11,
+}
+
+def changePitch(value):
+    logger.info(f"changePitch called: {value}")
+    try:
+        configuration.configData["midiPlayer"]["pitchOffset"] = PITCH_OFFSETS.get(value, 0)
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"changePitch error: {e}")
+
+def changeTranspose(value):
+    logger.info(f"changeTranspose called: {value}")
+    try:
+        configuration.configData["midiPlayer"]["transposeOffset"] = KEY_OFFSETS.get(value, 0)
+        configuration.configData.save()
+    except Exception as e:
+        logger.exception(f"changeTranspose error: {e}")
+
+def increaseSpeed():
+    logger.info("increaseSpeed called")
+    try:
+        useMIDI = configuration.configData["midiPlayer"]["useMIDIOutput"]
+        app.focus_set()
+
+        if useMIDI:
+            useOutput.changeSpeed(configuration.configData["midiPlayer"]["decreaseSize"] / 100)
+            app.playbackSpeed = round(useOutput.playbackSpeed * 100)
+        else:
+            midiHandler.changeSpeed(configuration.configData["midiPlayer"]["decreaseSize"] / 100)
+            app.playbackSpeed = round(midiHandler.playbackSpeed * 100)
+
+        MidiPlayerTab.speedSlider.set(app.playbackSpeed)
+        MidiPlayerTab.speedValueEntry.delete(0, "end")
+        MidiPlayerTab.speedValueEntry.insert(0, str(app.playbackSpeed))
+        logger.debug(f"increased playbackSpeed to: {app.playbackSpeed}")
+    except Exception as e:
+        logger.exception(f"increaseSpeed error: {e}")

--- a/modules/midiHandler/midiWindows.py
+++ b/modules/midiHandler/midiWindows.py
@@ -100,6 +100,10 @@ paused = False
 playThread = None
 playbackSpeed = 1.0
 sustainActive = False
+heldNoteCount = 0
+
+def getPianoFingerLimit():
+    return int(configuration.configData.get("midiPlayer", {}).get("fingerLimit", 11))
 
 def findVelocityKey(velocity):
     velocityMap = configuration.configData["midiPlayer"]["pianoMap"]["velocityMap"]
@@ -118,9 +122,19 @@ def findVelocityKey(velocity):
     return velocityMap[str(thresholds[index])]
 
 def pressAndMaybeRelease(key):
+    global heldNoteCount
+    limit = getPianoFingerLimit()
+    if limit <= 10 and heldNoteCount >= limit:
+        log(f"Finger limit ({limit}) reached, skipping note")
+        return
+    heldNoteCount += 1
     press(key)
     if configuration.configData["midiPlayer"]["customHoldLength"]["enabled"]:
-        t = threading.Timer(configuration.configData["midiPlayer"]["customHoldLength"]["noteLength"], lambda: release(key))
+        def _timerRelease():
+            global heldNoteCount
+            release(key)
+            heldNoteCount = max(0, heldNoteCount - 1)
+        t = threading.Timer(configuration.configData["midiPlayer"]["customHoldLength"]["noteLength"], _timerRelease)
         timerList.append(t)
         t.start()
 
@@ -181,6 +195,7 @@ def simulateKey(msgType, note, velocity):
             release("ctrl")
 
     elif msgType == "note_off":
+        global heldNoteCount
         if 36 <= note <= 96:
             if re.search("[!@$%^*(]", key):
                 release(letterNoteMap[str(note - 1)])
@@ -188,6 +203,7 @@ def simulateKey(msgType, note, velocity):
                 release(key.lower())
         else:
             release(key.lower())
+        heldNoteCount = max(0, heldNoteCount - 1)
 
 def parseMidi(message):
     global sustainActive
@@ -370,12 +386,13 @@ def changeSpeed(amount):
     log(f"Speed: {playbackSpeed * 100:.0f}%")
 
 def stopPlayback():
-    global closeThread, stopEvent, playThread, clockThreadRef, keyboardHandlers, timerList
+    global closeThread, stopEvent, playThread, clockThreadRef, keyboardHandlers, timerList, heldNoteCount
     if closeThread or stopEvent.is_set():
         return
     
     stopEvent.set()
     closeThread = True
+    heldNoteCount = 0
     for key in list(heldKeys):
         try:
             release(key)

--- a/modules/midiHandler/midiWindows.py
+++ b/modules/midiHandler/midiWindows.py
@@ -139,6 +139,7 @@ def pressAndMaybeRelease(key):
         t.start()
 
 def simulateKey(msgType, note, velocity):
+    note = note + configuration.configData["midiPlayer"].get("pitchOffset", 0) + configuration.configData["midiPlayer"].get("transposeOffset", 0)
     allow88 = configuration.configData["midiPlayer"]["88Keys"]
 
     letterNoteMap = configuration.configData["midiPlayer"]["pianoMap"]["61keyMap"]

--- a/modules/midiHandler/useOutput.py
+++ b/modules/midiHandler/useOutput.py
@@ -46,7 +46,8 @@ def parseMidi(message):
             return
 
     if message.type in ("note_on", "note_off"):
-        note = message.note
+        noteOffset = configuration.configData["midiPlayer"].get("pitchOffset", 0) + configuration.configData["midiPlayer"].get("transposeOffset", 0)
+        note = message.note + noteOffset
         if not noteAllowed(note):
             log(f"out of range: {note}")
             return

--- a/ui/drumsMacro.py
+++ b/ui/drumsMacro.py
@@ -209,6 +209,51 @@ class DrumsMacroTab(ctk.CTkFrame):
         self.timelineIndicator.grid(row=10, column=0, padx=(0, 50), pady=(0, 0), sticky="e")
         self.__class__.timelineIndicator = self.timelineIndicator
 
+        # FINGER LIMIT
+        _drumsInitLimit = configuration.configData.get("drumsMacro", {}).get("fingerLimit", 11)
+        _drumsInitDisplay = "∞" if _drumsInitLimit > 10 else str(_drumsInitLimit)
+
+        self.fingerLimitLabel = ctk.CTkLabel(
+            self.mainFrame, text="Fingers", fg_color="transparent", font=customTheme.globalFont14,
+            text_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["DrumsMacro"]["TextColorDisabled"]
+        )
+        self.fingerLimitLabel.grid(row=8, column=0, padx=(0, 290), pady=(5, 0))
+
+        self.fingerLimitSlider = ctk.CTkSlider(
+            self.mainFrame, from_=1, to=11, number_of_steps=10,
+            command=lambda value: settingsFunctions.changeDrumsFingerLimit(value),
+            fg_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["SpeedSliderBackColor"],
+            progress_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["SpeedSliderFillColor"],
+            button_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["SpeedSliderCircleColor"],
+            button_hover_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["SpeedSliderCircleHoverColor"]
+        )
+        self.fingerLimitSlider.grid(row=8, column=0, padx=(0, 50), pady=(5, 0))
+        self.fingerLimitSlider.set(_drumsInitLimit)
+        self.__class__.fingerLimitSlider = self.fingerLimitSlider
+        ToolTip.CreateToolTip(self.fingerLimitSlider, text='Max simultaneous keys (1-10)\nSlide past 10 for No Limit (∞)')
+
+        self.fingerLimitValueLabel = ctk.CTkLabel(
+            self.mainFrame, text=_drumsInitDisplay, width=50, font=customTheme.globalFont14,
+            fg_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["SpeedValueBoxBackColor"],
+            text_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["TextColor"],
+            corner_radius=6
+        )
+        self.fingerLimitValueLabel.grid(row=8, column=0, padx=(200, 0), pady=(5, 0))
+        self.__class__.fingerLimitValueLabel = self.fingerLimitValueLabel
+
+        self.resetFingerLimitButton = ctk.CTkButton(
+            self.mainFrame, image=customTheme.resetImageCTk, text="", width=30,
+            command=lambda: (self.fingerLimitSlider.set(11), settingsFunctions.changeDrumsFingerLimit(11)),
+            font=customTheme.globalFont14,
+            fg_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["ButtonColor"],
+            hover_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["ButtonHoverColor"],
+            text_color=customTheme.activeThemeData["Theme"]["DrumsMacro"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["DrumsMacro"]["TextColorDisabled"]
+        )
+        self.resetFingerLimitButton.grid(row=8, column=0, padx=(290, 0), pady=(5, 0))
+        ToolTip.CreateToolTip(self.resetFingerLimitButton, text='Reset Finger Limit to ∞')
+
         # SPEED CONTROL
         self.speedLabel = ctk.CTkLabel(
             self.mainFrame, text="Speed", fg_color="transparent", 

--- a/ui/midiPlayer.py
+++ b/ui/midiPlayer.py
@@ -293,6 +293,51 @@ class MidiPlayerTab(ctk.CTkFrame):
         self.timelineIndicator.grid(row=10, column=0, padx=(0, 50), pady=(0, 0), sticky="e")
         self.__class__.timelineIndicator = self.timelineIndicator
 
+        # FINGER LIMIT
+        _pianoInitLimit = configuration.configData.get("midiPlayer", {}).get("fingerLimit", 11)
+        _pianoInitDisplay = "∞" if _pianoInitLimit > 10 else str(_pianoInitLimit)
+
+        self.fingerLimitLabel = ctk.CTkLabel(
+            self.midiFrame, text="Fingers", fg_color="transparent", font=customTheme.globalFont14,
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.fingerLimitLabel.grid(row=8, column=0, padx=(0, 290), pady=(5, 0))
+
+        self.fingerLimitSlider = ctk.CTkSlider(
+            self.midiFrame, from_=1, to=11, number_of_steps=10, width=190,
+            command=lambda value: settingsFunctions.changePianoFingerLimit(value),
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderBackColor"],
+            progress_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderFillColor"],
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderCircleColor"],
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedSliderCircleHoverColor"]
+        )
+        self.fingerLimitSlider.grid(row=8, column=0, padx=(0, 50), pady=(5, 0))
+        self.fingerLimitSlider.set(_pianoInitLimit)
+        self.__class__.fingerLimitSlider = self.fingerLimitSlider
+        ToolTip.CreateToolTip(self.fingerLimitSlider, text='Max simultaneous keys (1-10)\nSlide past 10 for No Limit (∞)')
+
+        self.fingerLimitValueLabel = ctk.CTkLabel(
+            self.midiFrame, text=_pianoInitDisplay, width=50, font=customTheme.globalFont14,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["SpeedValueBoxBackColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            corner_radius=6
+        )
+        self.fingerLimitValueLabel.grid(row=8, column=0, padx=(200, 0), pady=(5, 0))
+        self.__class__.fingerLimitValueLabel = self.fingerLimitValueLabel
+
+        self.resetFingerLimitButton = ctk.CTkButton(
+            self.midiFrame, image=customTheme.resetImageCTk, text="", width=30,
+            command=lambda: (self.fingerLimitSlider.set(11), settingsFunctions.changePianoFingerLimit(11)),
+            font=customTheme.globalFont14,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonColor"],
+            hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["ButtonHoverColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.resetFingerLimitButton.grid(row=8, column=0, padx=(290, 0), pady=(5, 0))
+        ToolTip.CreateToolTip(self.resetFingerLimitButton, text='Reset Finger Limit to ∞')
+
         # SPEED CONTROL
         self.speedTextTitle = ctk.CTkLabel(
             self.midiFrame, text="Speed", fg_color="transparent", font=customTheme.globalFont14, 

--- a/ui/midiPlayer.py
+++ b/ui/midiPlayer.py
@@ -260,6 +260,62 @@ class MidiPlayerTab(ctk.CTkFrame):
         self.__class__.use88KeysToggle = self.use88KeysToggle
         ToolTip.CreateToolTip(self.use88KeysToggle, text = 'Simulate LowNote and HighNote by "CTRL"\nOnly works on supported games.')
 
+        # PITCH & KEY TRANSPOSE DROPDOWNS
+        _initPitchOffset = configuration.configData.get("midiPlayer", {}).get("pitchOffset", 0)
+        _pitchOffsetMap = {-24: "Lowest", -12: "Low", 0: "Middle", 12: "High", 24: "Highest"}
+        _initPitchLabel = _pitchOffsetMap.get(_initPitchOffset, "Middle")
+
+        _initTransposeOffset = configuration.configData.get("midiPlayer", {}).get("transposeOffset", 0)
+        _keyNames = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+        _initKeyLabel = _keyNames[_initTransposeOffset % 12] if 0 <= _initTransposeOffset <= 11 else "C"
+
+        self.pitchLabel = ctk.CTkLabel(
+            self.midiFrame, text="Pitch", fg_color="transparent", font=customTheme.globalFont14,
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.pitchLabel.grid(row=6, column=0, padx=(0, 210), pady=(10, 0))
+
+        self.pitchDropdown = ctk.CTkOptionMenu(
+            self.midiFrame, width=130, values=["Lowest", "Low", "Middle", "High", "Highest"],
+            font=customTheme.globalFont14, dropdown_font=customTheme.globalFont14,
+            command=midiPlayerFunctions.changePitch,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionBackColor"],
+            dropdown_fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownBackground"],
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonColor"],
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonHoverColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.pitchDropdown.set(_initPitchLabel)
+        self.pitchDropdown.grid(row=7, column=0, padx=(0, 190), pady=(4, 10))
+        self.__class__.pitchDropdown = self.pitchDropdown
+        ToolTip.CreateToolTip(self.pitchDropdown, text='Shift playback pitch by octaves\nLowest=-2oct  Low=-1oct  Middle=default\nHigh=+1oct  Highest=+2oct')
+
+        self.keyTransposeLabel = ctk.CTkLabel(
+            self.midiFrame, text="Key", fg_color="transparent", font=customTheme.globalFont14,
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.keyTransposeLabel.grid(row=6, column=0, padx=(220, 0), pady=(10, 0))
+
+        self.keyTransposeDropdown = ctk.CTkOptionMenu(
+            self.midiFrame, width=80,
+            values=["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"],
+            font=customTheme.globalFont14, dropdown_font=customTheme.globalFont14,
+            command=midiPlayerFunctions.changeTranspose,
+            fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionBackColor"],
+            dropdown_fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownBackground"],
+            button_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonColor"],
+            button_hover_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["OptionDropdownButtonHoverColor"],
+            text_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColor"],
+            text_color_disabled=customTheme.activeThemeData["Theme"]["MidiPlayer"]["TextColorDisabled"]
+        )
+        self.keyTransposeDropdown.set(_initKeyLabel)
+        self.keyTransposeDropdown.grid(row=7, column=0, padx=(230, 0), pady=(4, 10))
+        self.__class__.keyTransposeDropdown = self.keyTransposeDropdown
+        ToolTip.CreateToolTip(self.keyTransposeDropdown, text='Transpose playback by semitones\nC = no transpose (default)')
+
         # PLAYBACK BUTTONS
         self.playButton = ctk.CTkButton(
             self.midiFrame, text="Play", fg_color=customTheme.activeThemeData["Theme"]["MidiPlayer"]["PlayColor"], 


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><h1>Finger Limit Feature</h1>
<h2>Summary</h2>
<p>Adds a <strong>Finger Limit</strong> slider to both the Piano (MIDI Player) and Drums Macro tabs, allowing users to cap the maximum number of simultaneous key presses simulated at any given time. Sliding past 10 disables the limit entirely (Infinite / No Limit mode).</p>
<hr>
<h2>What's New</h2>
<h3>UI</h3>
<ul>
<li>New <strong>Finger Limit</strong> row added above the Speed slider in both the MIDI Player and Drums Macro tabs</li>
<li>Slider ranges from <strong>1 -> 10</strong> (enforced limit) with a live value display label showing the current count</li>
<li>Dragging past 10 snaps to <strong>Infinite</strong>, which is the default behaviour and is fully backwards compatible</li>
<li>Reset button restores the limit to Infinite</li>
<li>Tooltip on hover explains the control</li>
<li>Window height increased from <code>600x450</code> -> <code>600x490</code> to accommodate the new row</li>
</ul>
<h3>Engine (all platforms: Windows, macOS, Linux)</h3>
<ul>
<li><code>midiWindows.py</code>, <code>midiDarwin.py</code>, <code>midiLinux.py</code>: piano handlers now track <code>heldNoteCount</code> and skip new note presses when the finger limit is reached</li>
<li><code>drumsWindows.py</code>, <code>drumsDarwin.py</code>, <code>drumsLinux.py</code>: drums handlers apply the same logic to drum hits</li>
<li><code>heldNoteCount</code> decrements correctly on <code>note_off</code>, on timer-based releases (Custom Hold Length), and resets to <code>0</code> on <code>stopPlayback()</code></li>
<li>Finger limit is read live from config on every press, no restart required after changing the value</li>
</ul>
<h3>Config</h3>
<ul>
<li><code>fingerLimit: 11</code> added to both <code>midiPlayer</code> and <code>drumsMacro</code> sections of <code>defaultConfig.json</code></li>
<li>Value <code>11</code> = No Limit; values <code>1-10</code> = enforced cap</li>
<li>Setting persists across sessions</li>
</ul>
<hr>
<h2>Files Changed</h2>

File | Location | Change
-- | -- | --
midiPlayer.py | ui/ | Added Finger Limit slider row
drumsMacro.py | ui/ | Added Finger Limit slider row
settingsFunctions.py | modules/functions/ | Added changePianoFingerLimit() and changeDrumsFingerLimit()
midiWindows.py | modules/midiHandler/ | heldNoteCount tracking + limit enforcement
midiDarwin.py | modules/midiHandler/ | heldNoteCount tracking + limit enforcement
midiLinux.py | modules/midiHandler/ | heldNoteCount tracking + limit enforcement
drumsWindows.py | modules/midiHandler/ | heldNoteCount tracking + limit enforcement
drumsDarwin.py | modules/midiHandler/ | heldNoteCount tracking + limit enforcement
drumsLinux.py | modules/midiHandler/ | heldNoteCount tracking + limit enforcement
defaultConfig.json | assets/ | Added fingerLimit: 11 to midiPlayer and drumsMacro
main.py | / | Window height 450 -> 490


<hr>
<h2>Behaviour Details</h2>
<ul>
<li>When the limit is active and a new note would exceed it, the note is <strong>silently skipped</strong>, no crash, no stuck keys</li>
<li>Modifier keys (Shift, Ctrl, Alt, Space) are <strong>not</strong> counted toward the finger limit, only actual note key presses are tracked</li>
<li>The counter is independent of <code>heldKeys</code>, so it does not interfere with any existing key release logic</li>
<li>Compatible with <strong>Custom Hold Length</strong>, <strong>No Doubles</strong>, <strong>Velocity</strong>, <strong>88 Keys</strong>, and <strong>Random Fail</strong>, all existing features remain unaffected</li>
</ul>
<hr>
</body></html><!--EndFragment-->
</body>
</html>